### PR TITLE
LegalEntitySaga: fix periodic limits bounds setQuarterly

### DIFF
--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySaga.java
@@ -1308,7 +1308,7 @@ public class LegalEntitySaga implements StreamTaskExecutor<LegalEntityTask> {
             ofNullable(l.getDaily()).ifPresent(periodicLimits::setDaily);
             ofNullable(l.getWeekly()).ifPresent(periodicLimits::setWeekly);
             ofNullable(l.getMonthly()).ifPresent(periodicLimits::setMonthly);
-            ofNullable(l.getQuarterly()).ifPresent(periodicLimits::setDaily);
+            ofNullable(l.getQuarterly()).ifPresent(periodicLimits::setQuarterly);
         });
 
         return periodicLimits;

--- a/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySagaV2.java
+++ b/stream-legal-entity/legal-entity-core/src/main/java/com/backbase/stream/LegalEntitySagaV2.java
@@ -638,7 +638,7 @@ public class LegalEntitySagaV2 implements StreamTaskExecutor<LegalEntityTaskV2> 
             ofNullable(l.getDaily()).ifPresent(periodicLimits::setDaily);
             ofNullable(l.getWeekly()).ifPresent(periodicLimits::setWeekly);
             ofNullable(l.getMonthly()).ifPresent(periodicLimits::setMonthly);
-            ofNullable(l.getQuarterly()).ifPresent(periodicLimits::setDaily);
+            ofNullable(l.getQuarterly()).ifPresent(periodicLimits::setQuarterly);
         });
 
         return periodicLimits;


### PR DESCRIPTION
## Description

In the LegalEntitySagas the method `periodicLimits()` that collects `PeriodicLimitsBounds` had a minor typo where for `getQuarterly` it would overwite the `setDaily` value.

## Checklist

 - [x] I made sure, I read [CONTRIBUTING.md](CONTRIBUTING.md) to put right branch prefix as per my need.
 - [ ] I made sure to update [CHANGELOG.md](CHANGELOG.md). ~ will do when accepted by means of comment
 - [ ] I made sure to update [Stream Wiki](https://github.com/Backbase/stream-services/wiki)(only valid in case of new stream module or architecture changes). ~ N/A
 - [x] My changes are adequately tested.
 - [ ] I made sure all the SonarCloud Quality Gate are passed. ~ lets see what Github actions say, I'm optimistic :p
